### PR TITLE
Fix native commands not executing because of single quote

### DIFF
--- a/src/main/java/com/github/deetree/mantra/CreateInitCommitCommand.java
+++ b/src/main/java/com/github/deetree/mantra/CreateInitCommitCommand.java
@@ -17,7 +17,7 @@ class CreateInitCommitCommand implements NativeCommand {
 
     @Override
     public Result execute() {
-        if (execute(os, projectPath, "git add . && git commit -m 'Initial commit'") != Result.OK)
+        if (execute(os, projectPath, "git add . && git commit -m \"Initial commit\"") != Result.OK)
             throw new ActionException("An exception occurred during initial git commit creation");
         return Result.OK;
     }

--- a/src/main/java/com/github/deetree/mantra/LocalGitUserConfigCommand.java
+++ b/src/main/java/com/github/deetree/mantra/LocalGitUserConfigCommand.java
@@ -33,7 +33,7 @@ class LocalGitUserConfigCommand implements NativeCommand {
     }
 
     private Result configure(String configElement, String value) {
-        if (execute(os, projectPath, "git config user.%s '%s'".formatted(configElement, value)) != Result.OK)
+        if (execute(os, projectPath, "git config user.%s \"%s\"".formatted(configElement, value)) != Result.OK)
             throw new ActionException("An exception occurred during git user %s configuration"
                     .formatted(configElement));
         return Result.OK;


### PR DESCRIPTION
On Windows single quote is treated differently than on Linux, therefore some native commands did not execute as intended.
Closes #34 