### PR TITLE
Show help if no arguments were provided

### DIFF
--- a/src/main/java/com/github/deetree/mantra/Performer.java
+++ b/src/main/java/com/github/deetree/mantra/Performer.java
@@ -19,9 +19,9 @@ class Performer {
         CommandLine.ParseResult result = parsingResult.result();
         Helper usage = new UsageHelper(cmd);
         Helper version = new VersionHelper(cmd);
+        Arguments arguments = parsingResult.arguments();
 
-        if (!wasHelpUsed(usage, version)) {
-            Arguments arguments = parsingResult.arguments();
+        if (!wasHelpUsed(usage, version) && arguments.name != null) {
             Printer printer = new ConsolePrinter();
             printer.print(Level.INFO, "Resolving paths");
             Path projectPath = new ProjectPathResolver(arguments.directory, arguments.name).resolve();


### PR DESCRIPTION
If project name was not provided, the help was shown and the exception was thrown. Now the help is shown only.
Closes #29 