### PR TITLE
Fix unsupported OS exception handling

### DIFF
--- a/src/main/java/com/github/deetree/mantra/OSNotSupportedException.java
+++ b/src/main/java/com/github/deetree/mantra/OSNotSupportedException.java
@@ -1,0 +1,11 @@
+package com.github.deetree.mantra;
+
+/**
+ * @author Mariusz Bal
+ */
+class OSNotSupportedException extends RuntimeException {
+
+    OSNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/github/deetree/mantra/OperatingSystem.java
+++ b/src/main/java/com/github/deetree/mantra/OperatingSystem.java
@@ -9,7 +9,8 @@ class OperatingSystem {
         String os = System.getProperty("os.name").toLowerCase();
         if (os.contains("windows"))
             return OS.WINDOWS;
-        else //if (os.contains("nux") || os.contains("nix"))
+        else if (os.contains("nux") || os.contains("nix"))
             return OS.LINUX;
+        else throw new OSNotSupportedException("This operating system (%s) is not supported".formatted(os));
     }
 }

--- a/src/main/java/com/github/deetree/mantra/Performer.java
+++ b/src/main/java/com/github/deetree/mantra/Performer.java
@@ -68,7 +68,7 @@ class Performer {
                 printer.print(Level.INFO, "Opening the project in IntelliJ IDEA");
                 openIntelliJ(projectPath, os);
                 printer.print(Level.SUCCESS, "Project opened successfully");
-            } catch (ActionException e) {
+            } catch (ActionException | OSNotSupportedException e) {
                 printer.print(Level.ERROR, e.getMessage());
             }
         }


### PR DESCRIPTION
The exception is thrown if the detected operating system is not supported and it is handled accordingly so the user can see the proper status.
Closes #26 