### PR TITLE
Delete Trio class as it is no more needed

### DIFF
--- a/src/main/java/com/github/deetree/mantra/CLIParser.java
+++ b/src/main/java/com/github/deetree/mantra/CLIParser.java
@@ -15,11 +15,11 @@ class CLIParser {
         this.arguments = arguments;
     }
 
-    Trio parse() {
+    CommandLine parse() {
         CommandLine cmd = new CommandLine(arguments);
         cmd.setOverwrittenOptionsAllowed(true);
         cmd.setUnmatchedArgumentsAllowed(true);
         cmd.execute(args);
-        return new Trio(cmd, null, arguments);
+        return cmd;
     }
 }

--- a/src/main/java/com/github/deetree/mantra/Main.java
+++ b/src/main/java/com/github/deetree/mantra/Main.java
@@ -40,9 +40,7 @@ class Main {
             printer.print(WARNING, e.getMessage());
         }
 
-        Trio parsingResult = new CLIParser(args, arguments).parse();
-        CommandLine cmd = parsingResult.cmd();
-        arguments = parsingResult.arguments();
+        CommandLine cmd = new CLIParser(args, arguments).parse();
 
         Helper usage = new UsageHelper(cmd);
         Helper version = new VersionHelper(cmd);

--- a/src/main/java/com/github/deetree/mantra/Trio.java
+++ b/src/main/java/com/github/deetree/mantra/Trio.java
@@ -1,9 +1,0 @@
-package com.github.deetree.mantra;
-
-import picocli.CommandLine;
-import picocli.CommandLine.ParseResult;
-
-/**
- * @author Mariusz Bal
- */
-record Trio(CommandLine cmd, ParseResult result, Arguments arguments) {}

--- a/src/test/java/com/github/deetree/mantra/HelperTest.java
+++ b/src/test/java/com/github/deetree/mantra/HelperTest.java
@@ -13,9 +13,9 @@ import static org.testng.Assert.assertTrue;
 public class HelperTest {
 
     private final Helper versionHelper = new VersionHelper(new CLIParser(new String[]{"-V"},
-            new Arguments()).parse().cmd());
+            new Arguments()).parse());
     private final Helper usageHelper = new UsageHelper(new CLIParser(new String[]{"-h"},
-            new Arguments()).parse().cmd());
+            new Arguments()).parse());
     private ByteArrayOutputStream output;
 
     @BeforeMethod(onlyForGroups = "output")


### PR DESCRIPTION
There is no need now to return three objects simultaneously, so the `Trio` class may be removed.
Closes #31 