### PR TITLE
Use enum with system properties instead of specifying them redundantly

### DIFF
--- a/src/main/java/com/github/deetree/mantra/Arguments.java
+++ b/src/main/java/com/github/deetree/mantra/Arguments.java
@@ -23,7 +23,7 @@ class Arguments implements Runnable {
     String name;
 
     @Option(names = {"--directory", "-d"}, description = "Directory where the project will be created")
-    String directory = System.getProperty("user.home");
+    String directory = SystemProperty.USER_HOME.toString();
 
     @Option(names = {"--group", "-g"}, description = "Project's groupId")
     String groupId = "com.example";

--- a/src/main/java/com/github/deetree/mantra/Main.java
+++ b/src/main/java/com/github/deetree/mantra/Main.java
@@ -32,7 +32,7 @@ final class Main {
 
     public static void main(String[] args) {
         Main app = new Main(new Arguments(), Printer.getDefault(),
-                new File(System.getProperty("user.home"), ".mantra.config"));
+                new File(SystemProperty.USER_HOME.toString(), ".mantra.config"));
 
         final OS os = app.identifyOs();
         if (os != null) {

--- a/src/main/java/com/github/deetree/mantra/SystemProperty.java
+++ b/src/main/java/com/github/deetree/mantra/SystemProperty.java
@@ -1,0 +1,22 @@
+package com.github.deetree.mantra;
+
+/**
+ * System properties for being reused easily.
+ *
+ * @author Mariusz Bal
+ */
+public enum SystemProperty {
+    USER_HOME(System.getProperty("user.home")),
+    TMP_DIR(System.getProperty("java.io.tmpdir"));
+
+    private final String property;
+
+    SystemProperty(String property) {
+        this.property = property;
+    }
+
+    @Override
+    public String toString() {
+        return property;
+    }
+}

--- a/src/main/java/com/github/deetree/mantra/oscmd/LocateIntelliJCommand.java
+++ b/src/main/java/com/github/deetree/mantra/oscmd/LocateIntelliJCommand.java
@@ -2,6 +2,7 @@ package com.github.deetree.mantra.oscmd;
 
 import com.github.deetree.mantra.OS;
 import com.github.deetree.mantra.Result;
+import com.github.deetree.mantra.SystemProperty;
 import com.github.deetree.mantra.printer.Printer;
 
 import java.nio.file.Path;
@@ -37,7 +38,7 @@ class LocateIntelliJCommand implements NativeCommand {
 
     @Override
     public Result execute() {
-        return execute(os, Path.of(System.getProperty("user.home")),
+        return execute(os, Path.of(SystemProperty.USER_HOME.toString()),
                 findCommand().formatted(launcherPathFile.toString()), printer);
     }
 

--- a/src/test/java/com/github/deetree/mantra/CreateProjectIT.java
+++ b/src/test/java/com/github/deetree/mantra/CreateProjectIT.java
@@ -15,7 +15,7 @@ import java.nio.file.StandardCopyOption;
 @Test
 public class CreateProjectIT {
 
-    private final Path homePath = Path.of(System.getProperty("user.home"));
+    private final Path homePath = Path.of(SystemProperty.USER_HOME.toString());
     private final String projectName = "testProject";
     private final Path configFilePath = homePath.resolve(".mantra.config");
     private final Path configFileBackupPath = homePath.resolve(".mantra.config.backup");

--- a/src/test/java/com/github/deetree/mantra/creator/GitignoreCreatorIT.java
+++ b/src/test/java/com/github/deetree/mantra/creator/GitignoreCreatorIT.java
@@ -1,5 +1,6 @@
 package com.github.deetree.mantra.creator;
 
+import com.github.deetree.mantra.SystemProperty;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
@@ -12,7 +13,7 @@ public class GitignoreCreatorIT {
 
     public void shouldCopyGitignoreToDirectory() throws IOException {
         //g
-        Path directory = Path.of(System.getProperty("java.io.tmpdir"));
+        Path directory = Path.of(SystemProperty.TMP_DIR.toString());
         Path gitignore = directory.resolve(".gitignore");
         Creator creator = new GitignoreCreator(directory);
         //w

--- a/src/test/java/com/github/deetree/mantra/creator/MainClassCreatorIT.java
+++ b/src/test/java/com/github/deetree/mantra/creator/MainClassCreatorIT.java
@@ -1,5 +1,6 @@
 package com.github.deetree.mantra.creator;
 
+import com.github.deetree.mantra.SystemProperty;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
@@ -12,7 +13,7 @@ public class MainClassCreatorIT {
 
     public void shouldContainSubstitutedValues() throws IOException {
         //g
-        Path path = Path.of(System.getProperty("java.io.tmpdir"));
+        Path path = Path.of(SystemProperty.TMP_DIR.toString());
         String group = "testGroup";
         String artifact = "testArtifact";
         String main = "MainClass";

--- a/src/test/java/com/github/deetree/mantra/creator/PomCreatorIT.java
+++ b/src/test/java/com/github/deetree/mantra/creator/PomCreatorIT.java
@@ -1,5 +1,6 @@
 package com.github.deetree.mantra.creator;
 
+import com.github.deetree.mantra.SystemProperty;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -19,7 +20,7 @@ import static org.testng.Assert.assertEquals;
 @Test
 public class PomCreatorIT {
 
-    private final Path path = Path.of(System.getProperty("java.io.tmpdir"));
+    private final Path path = Path.of(SystemProperty.TMP_DIR.toString());
     private final Path pomPath = path.resolve("pom.xml");
     private final String group = "testGroup";
     private final String artifact = "testArtifact";

--- a/src/test/java/com/github/deetree/mantra/creator/TestClassCreatorIT.java
+++ b/src/test/java/com/github/deetree/mantra/creator/TestClassCreatorIT.java
@@ -1,5 +1,6 @@
 package com.github.deetree.mantra.creator;
 
+import com.github.deetree.mantra.SystemProperty;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
@@ -12,7 +13,7 @@ public class TestClassCreatorIT {
 
     public void shouldContainSubstitutedValues() throws IOException {
         //g
-        Path path = Path.of(System.getProperty("java.io.tmpdir"));
+        Path path = Path.of(SystemProperty.TMP_DIR.toString());
         String group = "testGroup";
         String artifact = "testArtifact";
         String main = "MainClass";

--- a/src/test/java/com/github/deetree/mantra/pathresolver/PathResolverTest.java
+++ b/src/test/java/com/github/deetree/mantra/pathresolver/PathResolverTest.java
@@ -1,5 +1,6 @@
 package com.github.deetree.mantra.pathresolver;
 
+import com.github.deetree.mantra.SystemProperty;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -11,7 +12,7 @@ import static org.testng.Assert.assertEquals;
 @Test
 public class PathResolverTest {
 
-    private final String directory = System.getProperty("java.io.tmpdir");
+    private final String directory = SystemProperty.TMP_DIR.toString();
     private final String projectName = "exampleProject";
     private final String src = "src";
     private final String group = "com.xyz.abc.def";


### PR DESCRIPTION
Instead of providing system property value every time, it can be declared once and reused.
Closes #80 