### PR TITLE
Refactor `Command#executeGit` method to use git username and email as parameters

### DIFF
--- a/src/main/java/com/github/deetree/mantra/Main.java
+++ b/src/main/java/com/github/deetree/mantra/Main.java
@@ -88,11 +88,10 @@ final class Main {
         ResolvedPaths paths = getResolvedPaths();
         try {
             createProject(paths);
-            Command command = Command.getDefault(paths.projectPath(), os,
-                    arguments.gitUsername, arguments.gitEmail, printer);
+            Command command = Command.getDefault(paths.projectPath(), os, printer);
 
             if (!arguments.disableGit)
-                command.executeGit();
+                command.executeGit(arguments.gitUsername, arguments.gitEmail);
             if (!arguments.skipIdea)
                 command.openIntelliJ();
         } catch (ActionException e) {

--- a/src/main/java/com/github/deetree/mantra/config/IdeLauncherAutoSave.java
+++ b/src/main/java/com/github/deetree/mantra/config/IdeLauncherAutoSave.java
@@ -37,8 +37,7 @@ class IdeLauncherAutoSave {
     String findPath() {
         try {
             Path launcherPathFile = Files.createTempFile("idea_launcher", ".path");
-            Command.getDefault(Path.of(""), os, "", "", printer)
-                    .locateIntelliJ(launcherPathFile);
+            Command.getDefault(Path.of(""), os, printer).locateIntelliJ(launcherPathFile);
             return Files.readString(launcherPathFile).strip();
         } catch (IOException e) {
             return "";

--- a/src/main/java/com/github/deetree/mantra/oscmd/BasicCommand.java
+++ b/src/main/java/com/github/deetree/mantra/oscmd/BasicCommand.java
@@ -18,8 +18,6 @@ class BasicCommand implements Command {
 
     private final Path projectPath;
     private final OS os;
-    private final String gitUsername;
-    private final String gitUserEmail;
     private final Printer printer;
 
     /**
@@ -31,19 +29,17 @@ class BasicCommand implements Command {
      * @param gitUserEmail local git user email
      * @param printer      output printer
      */
-    BasicCommand(Path projectPath, OS os, String gitUsername, String gitUserEmail, Printer printer) {
+    BasicCommand(Path projectPath, OS os, Printer printer) {
         this.projectPath = projectPath;
         this.os = os;
-        this.gitUsername = gitUsername;
-        this.gitUserEmail = gitUserEmail;
         this.printer = printer;
     }
 
     @Override
-    public Result executeGit() {
+    public Result executeGit(String username, String email) {
         Stream.of(
                 new InitializeGitCommand(os, projectPath, printer),
-                new LocalGitUserConfigCommand(os, projectPath, gitUsername, gitUserEmail, printer),
+                new LocalGitUserConfigCommand(os, projectPath, username, email, printer),
                 new CreateInitCommitCommand(os, projectPath, printer)
         ).forEach(this::executeCommand);
         return Result.OK;

--- a/src/main/java/com/github/deetree/mantra/oscmd/Command.java
+++ b/src/main/java/com/github/deetree/mantra/oscmd/Command.java
@@ -16,15 +16,13 @@ public interface Command {
     /**
      * Static factory method creating object for executing shell commands.
      *
-     * @param projectPath  project path
-     * @param os           operating system
-     * @param gitUsername  local git config username
-     * @param gitUserEmail local git config user email
-     * @param printer      printer
+     * @param projectPath project path
+     * @param os          operating system
+     * @param printer     printer
      * @return {@link BasicCommand} implementing native commands executing methods
      */
-    static Command getDefault(Path projectPath, OS os, String gitUsername, String gitUserEmail, Printer printer) {
-        return new BasicCommand(projectPath, os, gitUsername, gitUserEmail, printer);
+    static Command getDefault(Path projectPath, OS os, Printer printer) {
+        return new BasicCommand(projectPath, os, printer);
     }
 
     /**
@@ -32,7 +30,7 @@ public interface Command {
      *
      * @return command execution result
      */
-    Result executeGit();
+    Result executeGit(String username, String email);
 
     /**
      * IntelliJ opening native command.


### PR DESCRIPTION
Instead of creating command object in advance with git user config which is not used in all `Command` object methods.
Closes #92 