### PR TITLE
Update dependencies versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
         <project.project.build.encoding>UTF-8</project.project.build.encoding>
         <project.build.sourceEncoding>${project.project.build.encoding}</project.build.sourceEncoding>
         <project.build.targetEncoding>${project.project.build.encoding}</project.build.targetEncoding>
-        <testng.version>7.6.1</testng.version>
-        <picocli.version>4.6.3</picocli.version>
+        <testng.version>7.7.0</testng.version>
+        <picocli.version>4.7.0</picocli.version>
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
         <maven.dependency.plugin.version>3.2.0</maven.dependency.plugin.version>

--- a/src/main/resources/pom.xml
+++ b/src/main/resources/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.2.2</maven.jar.plugin.version>
         <maven.surefire.plugin.version>3.0.0-M5</maven.surefire.plugin.version>
-        <testng.version>7.6.0</testng.version>
+        <testng.version>7.7.0</testng.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The dependencies' versions are now up to date.
Previous TestNG version had a vulnerability.
Closes #99 