### PR TITLE
Change default project directory to current working dir

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -136,7 +136,7 @@ When you do not specify defaults neither in configuration file nor in command li
 ^|project name
 
 ^|`+directory+`
-^|user's home directory
+^|user's current working directory
 
 ^|`+git email+`
 ^|Global git user email (if provided, otherwise error while creating initial commit)

--- a/src/main/java/com/github/deetree/mantra/Arguments.java
+++ b/src/main/java/com/github/deetree/mantra/Arguments.java
@@ -28,7 +28,7 @@ class Arguments implements Runnable {
     String name;
 
     @Option(names = {"--directory", "-d"}, description = "Directory where the project will be created")
-    String directory = SystemProperty.USER_HOME.toString();
+    String directory = SystemProperty.USER_DIR.toString();
 
     @Option(names = {"--group", "-g"}, description = "Project's groupId")
     String groupId = "com.example";

--- a/src/main/java/com/github/deetree/mantra/SystemProperty.java
+++ b/src/main/java/com/github/deetree/mantra/SystemProperty.java
@@ -6,6 +6,7 @@ package com.github.deetree.mantra;
  * @author Mariusz Bal
  */
 public enum SystemProperty {
+    USER_DIR(System.getProperty("user.dir")),
     USER_HOME(System.getProperty("user.home")),
     TMP_DIR(System.getProperty("java.io.tmpdir"));
 


### PR DESCRIPTION
This way the project will be created in the directory where the mantra has been launched instead of home dir.
Closes #101 